### PR TITLE
[REMS-97] Adding PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+Check these steps before issuing the PR:
+- [] Ensure the target / base branch for any feature PR is set to `dev` not master (the only exception to this is releases from `dev` and hotfix branches)
+- [] Please make sure your PR Title is of the following syntax: `[REMS-##] Short Issue Name` if ready for review


### PR DESCRIPTION
Changed some of the branch rules in repo settings and adding a PR template for best practices transition now that we are release friendly.