### PR TITLE
ci-cd to publish windows porter fix image

### DIFF
--- a/.github/workflows/porter-windows-cd.yml
+++ b/.github/workflows/porter-windows-cd.yml
@@ -2,7 +2,7 @@ name: Porter Windows Docker Image CD
 
 on:
   push:
-    branches: [ master, windows-porter-install-fix ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/porter-windows-cd.yml
+++ b/.github/workflows/porter-windows-cd.yml
@@ -1,0 +1,27 @@
+name: Porter Invocation Docker Image CD
+
+on:
+  push:
+    branches: [ master, windows-porter-install-fix ]
+  workflow_dispatch:
+
+jobs:
+  docker-cd: 
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+      
+    - name: Build and push Server Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./Dockerfile.porter-windows
+        push: true
+        tags: codexrems/fullstack_rems-windows:REMSvCurrent

--- a/.github/workflows/porter-windows-cd.yml
+++ b/.github/workflows/porter-windows-cd.yml
@@ -1,4 +1,4 @@
-name: Porter Invocation Docker Image CD
+name: Porter Windows Docker Image CD
 
 on:
   push:
@@ -22,6 +22,6 @@ jobs:
     - name: Build and push Server Docker image
       uses: docker/build-push-action@v2
       with:
-        context: ./Dockerfile.porter-windows
+        context: Dockerfile.porter-windows
         push: true
         tags: codexrems/fullstack_rems-windows:REMSvCurrent

--- a/.github/workflows/porter-windows-cd.yml
+++ b/.github/workflows/porter-windows-cd.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Build and push Server Docker image
       uses: docker/build-push-action@v2
       with:
-        context: Dockerfile.porter-windows
+        context: .
+        file: Dockerfile.porter-windows
         push: true
         tags: codexrems/fullstack_rems-windows:REMSvCurrent

--- a/.github/workflows/porter-windows-cd.yml
+++ b/.github/workflows/porter-windows-cd.yml
@@ -19,7 +19,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
       
-    - name: Build and push Server Docker image
+    - name: Build and push Porter Windows Docker image
       uses: docker/build-push-action@v2
       with:
         context: .

--- a/.github/workflows/porter-windows-ci.yml
+++ b/.github/workflows/porter-windows-ci.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  pull_request:
+    branches: [ master, dev ]
+  workflow_dispatch:
+
+
+jobs:
+  docker-ci: 
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      
+    - name: Test Server Docker image Builds
+      run: docker build ./Dockerfile.porter-windows

--- a/.github/workflows/porter-windows-ci.yml
+++ b/.github/workflows/porter-windows-ci.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Porter Windows Docker Image CI
 
 on:
   pull_request:
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Test Server Docker image Builds
-      run: docker build ./Dockerfile.porter-windows
+      run: docker build Dockerfile.porter-windows

--- a/.github/workflows/porter-windows-ci.yml
+++ b/.github/workflows/porter-windows-ci.yml
@@ -14,5 +14,5 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v2
       
-    - name: Test Server Docker image Builds
+    - name: Test Porter Windows Docker image Builds
       run: docker build -f Dockerfile.porter-windows .

--- a/.github/workflows/porter-windows-ci.yml
+++ b/.github/workflows/porter-windows-ci.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Test Server Docker image Builds
-      run: docker build Dockerfile.porter-windows
+      run: docker build -f Dockerfile.porter-windows .

--- a/Dockerfile.porter-windows
+++ b/Dockerfile.porter-windows
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+WORKDIR /porter
+RUN apt update
+RUN apt -y install curl
+RUN curl -fsSL https://get.docker.com -o get-docker.sh
+RUN chmod u+x get-docker.sh
+RUN ./get-docker.sh
+RUN curl -L https://cdn.porter.sh/latest/install-linux.sh | bash
+RUN export PATH="$PATH:~/.porter"
+ENV PATH="$PATH:~/.porter" 


### PR DESCRIPTION
I found a solution to running Option 2 of the setup guide on windows, follow these steps:
 
1) docker pull codexrems/fullstack_rems-windows:REMSvCurrent
2) docker run -v /var/run/docker.sock:/var/run/docker.sock -ti --name porter-windows-container codexrems/fullstack_rems-windows:REMSvCurrent (this will run a docker container in interactive mode, giving you access to the containers shell for the rest of the commands.
 
In the interactive docker shell, run:
 
3) porter mixins install docker (step 4 of https://github.com/mcode/REMS/blob/master/DockerProdSetupGuideForMacOS.md#install-docker-desktop-for-mac)
4) porter mixins install docker-compose (step 4 of https://github.com/mcode/REMS/blob/master/DockerProdSetupGuideForMacOS.md#install-docker-desktop-for-mac)
5) porter install fullstack_rems --param vsac_api_key=${vsac_api_key} --allow-docker-host-access --reference codexrems/fullstack_rems:REMSvCurrent (https://github.com/mcode/REMS/blob/master/DockerProdSetupGuideForMacOS.md#install-and-run-porter-application)
 
You should now see the REMS solution servers spinning up and coming online.
 
To shut everything down after using the prototype, run the following commands:
 
1) ctrl + c (exits running porter process)
2) porter invoke fullstack_rems --action stop --param vsac_api_key=${vsac_api_key} --allow-docker-host-access (https://github.com/mcode/REMS/blob/master/DockerProdSetupGuideForMacOS.md#stop-running-porter-application)
3) ctrl + d (exits the interactive shell and shuts down the extra container ran in step 2 of the set up