### PR TITLE
REMS-173: Preload Keycloak logins

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - rems_dev_keycloak-data:/opt/jboss/keycloak/standalone/data/
       - '../test-ehr/src/main/resources/ClientFhirServerRealm.json:/resources/ClientFhirServerRealm.json'
-    image: hkong2/keycloak
+    image: jboss/keycloak:15.0.2
 
   # Create test ehr container
   test-ehr: # Name of our service


### PR DESCRIPTION
This includes bumping our keycloak version 7.0.1->15.0.2, which is the version that was used to generate our realm file in the test-ehr repo. Prior to this, the import of the realm file was not working, due to incompatibilities with keycloak version 7.0.1.

Note that if you have run this docker compose before, you will need to ensure that the volume used by the keycloak container, `rems_dev_rems_dev_keycloak-data`, is removed.

Corresponding PR, which includes the user data: https://github.com/mcode/test-ehr/pull/17