### PR TITLE
added patient status forms to etasu

### DIFF
--- a/src/fhir/utilities.ts
+++ b/src/fhir/utilities.ts
@@ -133,28 +133,40 @@ export class FhirUtilities {
             description: 'Submit Patient Enrollment form to the REMS Administrator',
             stakeholderType: 'patient',
             createNewCase: true,
-            resourceId: 'TuralioRemsPatientEnrollment'
+            resourceId: 'TuralioRemsPatientEnrollment',
+            requiredToDispense: true
           },
           {
             name: 'Prescriber Enrollment',
             description: 'Submit Prescriber Enrollment form to the REMS Administrator',
             stakeholderType: 'prescriber',
             createNewCase: false,
-            resourceId: 'TuralioPrescriberEnrollmentForm'
+            resourceId: 'TuralioPrescriberEnrollmentForm',
+            requiredToDispense: true
           },
           {
             name: 'Prescriber Knowledge Assessment',
             description: 'Submit Prescriber Knowledge Assessment form to the REMS Administrator',
             stakeholderType: 'prescriber',
             createNewCase: false,
-            resourceId: 'TuralioPrescriberKnowledgeAssessment'
+            resourceId: 'TuralioPrescriberKnowledgeAssessment',
+            requiredToDispense: true
           },
           {
             name: 'Pharmacist Enrollment',
             description: 'Submit Pharmacist Enrollment form to the REMS Administrator',
             stakeholderType: 'pharmacist',
             createNewCase: false,
-            resourceId: 'TuralioPharmacistEnrollment'
+            resourceId: 'TuralioPharmacistEnrollment',
+            requiredToDispense: true
+          },
+          {
+            name: 'Patient Status Update Form',
+            description: 'Submit Patient Status Update form to the REMS Administrator',
+            stakeholderType: 'patient',
+            createNewCase: false,
+            resourceId: 'TuralioRemsPatientStatus',
+            requiredToDispense: false
           }
         ]
       },
@@ -168,35 +180,40 @@ export class FhirUtilities {
             description: 'Submit Patient Enrollment form to the REMS Administrator',
             stakeholderType: 'patient',
             createNewCase: true,
-            resourceId: 'TIRFRemsPatientEnrollment'
+            resourceId: 'TIRFRemsPatientEnrollment',
+            requiredToDispense: true
           },
           {
             name: 'Prescriber Enrollment',
             description: 'Submit Prescriber Enrollment form to the REMS Administrator',
             stakeholderType: 'prescriber',
             createNewCase: false,
-            resourceId: 'TIRFPrescriberEnrollmentForm'
+            resourceId: 'TIRFPrescriberEnrollmentForm',
+            requiredToDispense: true
           },
           {
             name: 'Prescriber Knowledge Assessment',
             description: 'Submit Prescriber Knowledge Assessment form to the REMS Administrator',
             stakeholderType: 'prescriber',
             createNewCase: false,
-            resourceId: 'TIRFPrescriberKnowledgeAssessment'
+            resourceId: 'TIRFPrescriberKnowledgeAssessment',
+            requiredToDispense: true
           },
           {
             name: 'Pharmacist Enrollment',
             description: 'Submit Pharmacist Enrollment form to the REMS Administrator',
             stakeholderType: 'pharmacist',
             createNewCase: false,
-            resourceId: 'TIRFPharmacistEnrollmentForm'
+            resourceId: 'TIRFPharmacistEnrollmentForm',
+            requiredToDispense: true
           },
           {
             name: 'Pharmacist Knowledge Assessment',
             description: 'Submit Pharmacist Knowledge Assessment form to the REMS Administrator',
             stakeholderType: 'pharmacist',
             createNewCase: false,
-            resourceId: 'TIRFPharmacistKnowledgeAssessment'
+            resourceId: 'TIRFPharmacistKnowledgeAssessment',
+            requiredToDispense: true
           }
         ]
       },
@@ -210,21 +227,24 @@ export class FhirUtilities {
             description: 'Submit Patient Enrollment form to the REMS Administrator',
             stakeholderType: 'patient',
             createNewCase: true,
-            resourceId: 'IPledgeRemsPatientEnrollment'
+            resourceId: 'IPledgeRemsPatientEnrollment',
+            requiredToDispense: true
           },
           {
             name: 'Prescriber Enrollment',
             description: 'Submit Prescriber Enrollment form to the REMS Administrator',
             stakeholderType: 'prescriber',
             createNewCase: false,
-            resourceId: 'IPledgeRemsPrescriberEnrollmentForm'
+            resourceId: 'IPledgeRemsPrescriberEnrollmentForm',
+            requiredToDispense: true
           },
           {
             name: 'Pharmacist Enrollment',
             description: 'Submit Pharmacist Enrollment form to the REMS Administrator',
             stakeholderType: 'pharmacist',
             createNewCase: false,
-            resourceId: 'IPledgeRemsPharmacistEnrollmentForm'
+            resourceId: 'IPledgeRemsPharmacistEnrollmentForm',
+            requiredToDispense: true
           }
         ]
       }


### PR DESCRIPTION
## Describe your changes

 This PR handles submitting patient status forms at regular intervals in the REMS-Admin system. 

Turalio is the only medication right now that has a Patient Status Form. 

To Test:
Run through workflow like normal for Turalio, submit patient enrollment and complete all ETASU. After all ETASU have been met you can then submit the Patient Enrollment Form. Go back to ETASU page to see that the Patient Status ETASU shows with date. 

![Screenshot 2023-07-28 at 10 30 32 AM](https://github.com/mcode/REMS/assets/28585306/071ac619-068d-4997-86d0-5fe77315f350)

You should be able to submit multiple Patient Status Forms. Make sure to close out of the Patient Status Form tab and then go back and submit another form. Should show up then in the ETASU view. 

## Issue ticket number and Jira link

[REMS-349](https://jira.mitre.org/browse/REMS-349)

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you.

